### PR TITLE
Bugfix - AttributeError: 'list' object has no attribute 'x'

### DIFF
--- a/tools/DatasetViewer/DataViewer_V2.py
+++ b/tools/DatasetViewer/DataViewer_V2.py
@@ -98,7 +98,7 @@ class DatasetViewer(QtGui.QMainWindow):
         # self.showMaximized()
 
         self.w = gl.GLViewWidget()
-        self.w.setCameraPosition(pos=[0, 0, 0], distance=10, azimuth=180, elevation=10)
+        self.w.setCameraPosition(pos=QtGui.QVector3D(0, 0, 0), distance=10, azimuth=180, elevation=10)
         self.initComboBoxes()
 
         self.update_sample()
@@ -694,7 +694,7 @@ class DatasetViewer(QtGui.QMainWindow):
                 self.badSensorCheckBox.setEnabled(True)
 
     def resetViewButton_clicked(self):
-        self.w.setCameraPosition(pos=[0, 0, 0], distance=10, azimuth=180, elevation=10)
+        self.w.setCameraPosition(pos=QtGui.QVector3D(0, 0, 0), distance=10, azimuth=180, elevation=10)
 
     def goToIndexEdit_returnPressed(self):
         try:


### PR DESCRIPTION
Fixes the following bug (on MacOS)
```bash
Traceback (most recent call last):
  File "/Users/Hahner/anaconda3/envs/DENSE/lib/python3.7/site-packages/pyqtgraph/opengl/GLViewWidget.py", line 189, in paintGL
    self.setModelview()
  File "/Users/Hahner/anaconda3/envs/DENSE/lib/python3.7/site-packages/pyqtgraph/opengl/GLViewWidget.py", line 142, in setModelview
    m = self.viewMatrix()
  File "/Users/Hahner/anaconda3/envs/DENSE/lib/python3.7/site-packages/pyqtgraph/opengl/GLViewWidget.py", line 152, in viewMatrix
    tr.translate(-center.x(), -center.y(), -center.z())
AttributeError: 'list' object has no attribute 'x'

Process finished with exit code 1
```